### PR TITLE
Update base README.md & profile readme to not duplicate banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-![banner](https://github.com/typst-community/.github/assets/69181766/9f48b467-c942-4190-a487-e3a1f5f810d9)
+<p align="center">
+  <a href="https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file">Community health files</a>
+  | <a href="https://github.com/typst-community">Our profile</a>
+</p>

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,1 +1,1 @@
-![banner](https://github.com/typst-community/.github/assets/69181766/9f48b467-c942-4190-a487-e3a1f5f810d9)
+<sub>[⭐ Check out the official Typst project's GitHub page too!](https://github.com/typst)</sub>


### PR DESCRIPTION
The current banner image is a bit uninformative. There's the profile/README.md and then the root README.md. the profile/README.md should ideally:

- Provide any quick links to things like docs, installation, etc.
- Probably link to the official @typst project
- Maybe list some additional Typst installation methods?

Whereas the root README.md should probably do one of two things.
Either: link to info on community health files and provide a "did you mean to go to github.com/typst-community"
OR: provide sort of an about page of "what is this project, no really I didn't get enough from github.com/typst-community"

Right now since the @typst-community has literally 1 repo I think it's best to keep it simple and just go with a basic "here's what this magic .github repo does" and "did you mean our profile?" links

Why that instead of the banner? You already have a banner! 😅
![image](https://github.com/typst-community/.github/assets/61068799/365b42b1-1039-4330-bb58-ad68a1c9edf7)

idk tho just an idea.

For some ideas of "good" (imo) .github/profile/README.md:
- https://github.com/nodejs
- https://github.com/github
- https://github.com/asdf-community
- https://github.com/twitter
- https://github.com/IBM

BUT AGAIN start small! Heck, if you wanted you could get rid of the profile/README.md until it's a good time if you want. The double banner irks me though lol

This PR would:
- remove banner from root reamde
- add link to github docs about community health files to root readme
- add link to profile page to root readme
- remove banner from profile readme
- add link to official @typst in profile readme