### PR TITLE
Add links to other @typst-community related things to .github readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-![banner](https://github.com/typst-community/.github/assets/69181766/9f48b467-c942-4190-a487-e3a1f5f810d9)
+# Typst Community
+
+**[@typst-community] on other platforms**
+
+- [typst-community on Wasmer](https://wasmer.io/typst-community)
+- [@typst-community on npm](https://www.npmjs.com/org/typst-community)
+
+**Other cool Typst projects**
+
+- Typst WinGet package &mdash; [source](https://github.com/microsoft/winget-pkgs/tree/master/manifests/t/Typst/Typst)
+- [Typst Arch Linux package](https://archlinux.org/packages/extra/x86_64/typst/) &mdash; [source](https://gitlab.archlinux.org/archlinux/packaging/packages/typst)
+
+[@typst-community]: https://github.com/typst-community


### PR DESCRIPTION
Think of it like an index of typst-related community projects even if they're not under the @typst-community umbrella.

Why here instead of profile readme:
profile readme should be for homepage-like things, not aboutpage-like things